### PR TITLE
Search page setup

### DIFF
--- a/src/nswdesignsystem/plone6/setuphandlers.py
+++ b/src/nswdesignsystem/plone6/setuphandlers.py
@@ -62,8 +62,7 @@ def create_global_search_page(context):
             "e633675a-8067-49cb-97c5-b74ac7314f53",
         ]
     }
-    # TODO: Exclude from navigation
-    # TODO: Set the facets section title to 'Filter results'
+    search_page.exclude_from_nav = True
 
 
 def post_install(context):


### PR DESCRIPTION
This PR creates a search page at `/search` with the following settings on install:

- Has a `title` block
- Has a search block which:
  - Uses the root of the site for the search path
  - Doesn't show Image or File content types
  - Uses the default batch size
  - Has the 'Sort by' option enable and allows users to select _Sortable title_ or _Creation date_