### PR TITLE
Volto subfooter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "plone.api>=1.8.4",
         "plone.app.dexterity",
         "collective.volto.formsupport==2.4.0",
+        "collective.volto.subfooter==1.1.0",
     ],
     extras_require={
         "test": [

--- a/src/nswdesignsystem/plone6/dependencies.zcml
+++ b/src/nswdesignsystem/plone6/dependencies.zcml
@@ -5,4 +5,5 @@
   i18n_domain="nswdesignsystem.plone6">
 
   <include package="collective.volto.formsupport" />
+  <include package="collective.volto.subfooter" />
 </configure>

--- a/src/nswdesignsystem/plone6/profiles/default/metadata.xml
+++ b/src/nswdesignsystem/plone6/profiles/default/metadata.xml
@@ -3,5 +3,6 @@
   <version>1000</version>
   <dependencies>
     <dependency>profile-collective.volto.formsupport:default</dependency>
+    <dependency>profile-collective.volto.subfooter:default</dependency>
   </dependencies>
 </metadata>

--- a/src/nswdesignsystem/plone6/profiles/default/registry/main.xml
+++ b/src/nswdesignsystem/plone6/profiles/default/registry/main.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0"?>
-<registry
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="nswdesignsystem.plone6">
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  i18n:domain="nswdesignsystem.plone6">
 
-<!-- -*- extra stuff goes here -*- -->
+  <!-- -*- extra stuff goes here -*- -->
+  <record name="collective.volto.subfooter.interfaces.ISubfooter.subfooter_configuration"
+    interface="collective.volto.subfooter.interfaces.ISubfooter"
+    field="subfooter_configuration">
+    <value>[{"rootPath": "Lower footer", "items": []}]</value>
+  </record>
+
+
 
 </registry>

--- a/src/nswdesignsystem/plone6/tests/test_setup.py
+++ b/src/nswdesignsystem/plone6/tests/test_setup.py
@@ -37,6 +37,9 @@ class TestSetup(unittest.TestCase):
         self.assertTrue(
             self.installer.is_product_installed("collective.volto.formsupport")
         )
+        self.assertTrue(
+            self.installer.is_product_installed("collective.volto.subfooter")
+        )
 
     def test_browserlayer(self):
         """Test that INswdesignsystemPlone6Layer is registered."""


### PR DESCRIPTION
This PR adds the setup needed to use `volto-subfooter`, allowing editable footer contents