### PR TITLE
Add cusy.restapi.info view permission to all users

### DIFF
--- a/src/nswdesignsystem/plone6/profiles/default/rolemap.xml
+++ b/src/nswdesignsystem/plone6/profiles/default/rolemap.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <rolemap>
   <permissions>
-  <!-- -*- extra stuff goes here -*- -->
-
+    <permission name="SiteInfo: Access Site Info"
+      acquire="True">
+      <role name="Anonymous"/>
+    </permission>
   </permissions>
 </rolemap>


### PR DESCRIPTION
The version of cusy.restapi.info required by the NSW Design System Plone6 implementation has a role of `cusy.restapi.siteinfo` that needs to be added to `Anonymous` so that the siteinfo can be fetched by all users.