### PR TITLE
Fix REST API response when serialization type isn't what is excepted

### DIFF
--- a/news/19.bugfix
+++ b/news/19.bugfix
@@ -1,0 +1,2 @@
+Fixed exception handling when `@nswSiteSettings` serialization is a dictionary not a JSON string
+[@JeffersonBledsoe]

--- a/src/nswdesignsystem/plone6/restapi/get.py
+++ b/src/nswdesignsystem/plone6/restapi/get.py
@@ -49,4 +49,4 @@ class NSWSiteSettingsGet(Service):
         if not records:
             return {}
 
-        return serialize_data(json_data=records)
+        return serialize_data(json_data=records, request=self.request)


### PR DESCRIPTION
Sometimes (I'm not sure why), the serializer will be passed the dictionary when making a request rather than the JSON string. #15 updated the exception handling in an incorrect manner. This PR adds some extra guards in addition to return to the previous behaviour